### PR TITLE
Add --help and dont set hostname if not specified in non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo fa
 
 Yup. That's it. If you want to run Fetch Apply manually, just type `fa` into your terminal... and you're done!
 
-This command will do a git pull to fetch your operations repository, then apply!
+`fa` will now execute a `git pull` to grab the latest updates to your `operations` repository, and then apply any of the applicable `modules` or (new) `initializers` as outlined therein!
 
 #### The full command documentation, for those of you interested:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ sudo fa
 
 Yup. That's it. If you want to run Fetch Apply manually, just type `fa` into your terminal... and you're done!
 
+This command will do a git pull to fetch your operations repository, then apply!
+
 #### The full command documentation, for those of you interested:
 
 ```

--- a/install
+++ b/install
@@ -17,18 +17,18 @@ FA_GIT_URL="https://github.com/P5vc/FetchApply.git"
 INSTALLATION_PATH="/var/lib"
 LOG_FILE_PATH="/var/log/fetchapply.log"
 OPERATIONS_GIT_URL="https://github.com/P5vc/ServerConfigurations.git"
-SERVER_HOSTNAME="$(hostname)"
+SERVER_HOSTNAME=""
 CRONTAB_ENTRY="$(( RANDOM % 60 )) $(( RANDOM % 24 )) * * *"
 
 function show_help()
 {
 	echo "Usage: `basename $0` [OPTIONS]"
 	echo "    where allowed options are:"
-	echo "         --installation-path=/var/lib				Where to install fetchapply to"
-	echo "         --log-file-path=/var/log/fetchapply.log                  Where to log fetchapply output to"
-	echo "         --operations-git-url=https://github.com/me/fa.git	The git repo containing your fa config"
-	echo "         --server-hostname=my-server				If specified, the hostname will be set to this"
-	echo "         --crontab-entry=*/30 * * * *				How often to run fetchapply (default is once a day at a random hour/minute)"
+	echo "         --installation-path=/var/lib                        Where to install fetchapply to"
+	echo "         --log-file-path=/var/log/fetchapply.log             Where to log fetchapply output to"
+	echo "         --operations-git-url=https://github.com/me/fa.git   The git repo containing your fa config"
+	echo "         --server-hostname=my-server                         If specified, the hostname will be set to this, otherwise left as is"
+	echo "         --crontab-entry='*/30 * * * *'                      How often to run fetchapply (default is once a day at a random hour/minute)"
 	exit 0
 }
 
@@ -133,7 +133,7 @@ function interactive()
 	read SERVER_HOSTNAME
 	if [ -z "$SERVER_HOSTNAME" ]
 	then
-		SERVER_HOSTNAME="server"
+		SERVER_HOSTNAME="$(hostname)"
 	fi
 
 	echo -e "\n\n${BLUE}What is the desired Fetch Apply run frequency? The default is once every 24 hours.\n${CYAN}Run frequency in crontab syntax (${CRONTAB_ENTRY}):${NO_COLOR}"

--- a/install
+++ b/install
@@ -17,9 +17,20 @@ FA_GIT_URL="https://github.com/P5vc/FetchApply.git"
 INSTALLATION_PATH="/var/lib"
 LOG_FILE_PATH="/var/log/fetchapply.log"
 OPERATIONS_GIT_URL="https://github.com/P5vc/ServerConfigurations.git"
-SERVER_HOSTNAME="server"
+SERVER_HOSTNAME="$(hostname)"
 CRONTAB_ENTRY="$(( RANDOM % 60 )) $(( RANDOM % 24 )) * * *"
 
+function show_help()
+{
+	echo "Usage: `basename $0` [OPTIONS]"
+	echo "    where allowed options are:"
+	echo "         --installation-path=/var/lib				Where to install fetchapply to"
+	echo "         --log-file-path=/var/log/fetchapply.log                  Where to log fetchapply output to"
+	echo "         --operations-git-url=https://github.com/me/fa.git	The git repo containing your fa config"
+	echo "         --server-hostname=my-server				If specified, the hostname will be set to this"
+	echo "         --crontab-entry=*/30 * * * *				How often to run fetchapply (default is once a day at a random hour/minute)"
+	exit 0
+}
 
 function install()
 {
@@ -35,7 +46,10 @@ function install()
 
 	echo -e "\n\n${GREEN}Beginning installation...${PURPLE}"
 
-	hostnamectl set-hostname $SERVER_HOSTNAME
+	if [[ ! -z "$SERVER_HOSTNAME" ]]
+	then
+		hostnamectl set-hostname $SERVER_HOSTNAME
+	fi
 
 	mkdir -p ${INSTALLATION_PATH}/fetchapply
 	git clone $FA_GIT_URL ${INSTALLATION_PATH}/fetchapply
@@ -143,6 +157,10 @@ do
 	if [ "$argument" == "--uninstall" ]
 	then
 		uninstall
+		exit 0
+	elif [ "$argument" == "--help" ]
+	then
+		show_help
 		exit 0
 	elif [ "${argument:0:20}" == "--installation-path=" ]
 	then

--- a/install
+++ b/install
@@ -17,19 +17,32 @@ FA_GIT_URL="https://github.com/P5vc/FetchApply.git"
 INSTALLATION_PATH="/var/lib"
 LOG_FILE_PATH="/var/log/fetchapply.log"
 OPERATIONS_GIT_URL="https://github.com/P5vc/ServerConfigurations.git"
-SERVER_HOSTNAME=""
+SERVER_HOSTNAME="$(hostname)"
 CRONTAB_ENTRY="$(( RANDOM % 60 )) $(( RANDOM % 24 )) * * *"
 
-function show_help()
+function usage()
 {
-	echo "Usage: `basename $0` [OPTIONS]"
-	echo "    where allowed options are:"
-	echo "         --installation-path=/var/lib                        Where to install fetchapply to"
-	echo "         --log-file-path=/var/log/fetchapply.log             Where to log fetchapply output to"
-	echo "         --operations-git-url=https://github.com/me/fa.git   The git repo containing your fa config"
-	echo "         --server-hostname=my-server                         If specified, the hostname will be set to this, otherwise left as is"
-	echo "         --crontab-entry='*/30 * * * *'                      How often to run fetchapply (default is once a day at a random hour/minute)"
-	exit 0
+cat <<EOF
+Fetch Apply Installation Script
+
+Usage:
+    `basename $0` [OPTIONS]
+
+Options and Default Values:
+    --uninstall
+        Uninstall Fetch Apply
+    --installation-path=/var/lib
+        Fetch Apply installation location
+    --log-file-path=/var/log/fetchapply.log
+        Fetch Apply log location
+    --server-hostname=${SERVER_HOSTNAME}
+        Server hostname to use
+    --operations-git-url=https://github.com/P5vc/ServerConfigurations.git
+        URL to your operations (Fetch Apply configuration) repository
+    --crontab-entry="0 0 * * *"
+        Crontab entry indicating how often to run Fetch Apply; the default is to run
+        Fetch Apply at a random time (determined upon installation), once every 24 hours.
+EOF
 }
 
 function install()
@@ -46,10 +59,7 @@ function install()
 
 	echo -e "\n\n${GREEN}Beginning installation...${PURPLE}"
 
-	if [[ ! -z "$SERVER_HOSTNAME" ]]
-	then
-		hostnamectl set-hostname $SERVER_HOSTNAME
-	fi
+	hostnamectl set-hostname $SERVER_HOSTNAME
 
 	mkdir -p ${INSTALLATION_PATH}/fetchapply
 	git clone $FA_GIT_URL ${INSTALLATION_PATH}/fetchapply
@@ -129,11 +139,11 @@ function interactive()
 		OPERATIONS_GIT_URL="https://github.com/P5vc/ServerConfigurations.git"
 	fi
 
-	echo -e "\n\n${BLUE}What is the desired hostname for this server?\n${CYAN}Hostname (server):${NO_COLOR}"
-	read SERVER_HOSTNAME
-	if [ -z "$SERVER_HOSTNAME" ]
+	echo -e "\n\n${BLUE}What is the desired hostname for this server?\n${CYAN}Hostname (${SERVER_HOSTNAME}):${NO_COLOR}"
+	read SERVER_HOSTNAME_CHANGED
+	if [ -n "$SERVER_HOSTNAME_CHANGED" ]
 	then
-		SERVER_HOSTNAME="$(hostname)"
+		SERVER_HOSTNAME="${SERVER_HOSTNAME_CHANGED}"
 	fi
 
 	echo -e "\n\n${BLUE}What is the desired Fetch Apply run frequency? The default is once every 24 hours.\n${CYAN}Run frequency in crontab syntax (${CRONTAB_ENTRY}):${NO_COLOR}"
@@ -160,7 +170,7 @@ do
 		exit 0
 	elif [ "$argument" == "--help" ]
 	then
-		show_help
+		usage
 		exit 0
 	elif [ "${argument:0:20}" == "--installation-path=" ]
 	then


### PR DESCRIPTION
Feel free to suggest changes as this changes the hostname behaviour a little. I don't want to have to manually set the hostname every time I install this as I'd like it to take the hostname that the system already has, meaning I can mass-automate the install on many servers. However the interactive behaviour hasn't changed except to use the existing hostname instead of setting it to "server" if it's not provided.